### PR TITLE
Move content beneath the icons on homescreen

### DIFF
--- a/app/src/main/res/layout/home_parking_layout.xml
+++ b/app/src/main/res/layout/home_parking_layout.xml
@@ -45,11 +45,14 @@
         <com.mttnow.coolestprojects.screens.fragments.ui.CustomTextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/content_value_margin_top"
+            android:layout_marginTop="9dp"
             android:text="@string/home_parking_desc"
             android:textColor="@color/home_content_text_color"
             android:textSize="@dimen/container_content_size"
-            custom:font="OpenSans-Regular.ttf"/>
+            custom:font="OpenSans-Regular.ttf"
+            android:layout_below="@+id/parking_logo"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true" />
 
 
     </RelativeLayout>

--- a/app/src/main/res/layout/home_times.xml
+++ b/app/src/main/res/layout/home_times.xml
@@ -6,12 +6,14 @@
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:background="@color/home_content_bg"
-    android:paddingTop="@dimen/home_desc_vertical_padding">
+    android:paddingTop="@dimen/home_desc_vertical_padding"
+    android:weightSum="1">
 
     <RelativeLayout
+        style="@style/contentWhiteBoxRoundedCornerStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        style="@style/contentWhiteBoxRoundedCornerStyle"
+        android:layout_weight="0.67"
         android:orientation="vertical">
 
 
@@ -19,9 +21,9 @@
             android:id="@+id/home_logo"
             android:layout_width="@dimen/icon_width"
             android:layout_height="wrap_content"
-            android:adjustViewBounds="true"
             android:layout_alignParentRight="true"
-            android:src="@drawable/time_icon"/>
+            android:adjustViewBounds="true"
+            android:src="@drawable/time_icon" />
 
         <com.mttnow.coolestprojects.screens.fragments.ui.CustomTextView
             android:id="@+id/event_times_title"
@@ -29,19 +31,22 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
             android:text="@string/event_times"
-            android:textStyle="bold"
             android:textColor="@color/home_content_text_color"
             android:textSize="@dimen/container_title_size"
-            custom:font="OpenSans-Bold.ttf"/>
+            android:textStyle="bold"
+            custom:font="OpenSans-Bold.ttf" />
 
         <com.mttnow.coolestprojects.screens.fragments.ui.CustomTextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/content_value_margin_top"
             android:text="@string/event_times_descr"
             android:textColor="@color/home_content_text_color"
             android:textSize="@dimen/container_content_size"
-            custom:font="OpenSans-Regular.ttf"/>
+            custom:font="OpenSans-Regular.ttf"
+            android:layout_below="@+id/home_logo"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_marginTop="12dp" />
 
-      </RelativeLayout>
+    </RelativeLayout>
 </LinearLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:3.0.0'
 


### PR DESCRIPTION
On xxhdpi devices the text currently overlaps with the icons on the home
screen. This change moves it beneath the icon.